### PR TITLE
Redefine types using `Tensor` types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,10 @@ version = "0.1.0"
 [deps]
 Crystallography = "3bff3928-7a76-11e9-2089-d112443085a5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tensorial = "98f94333-fa9f-48a9-ad80-1c66397b2b38"
 
 [compat]
 Crystallography = "0.2, 0.3"
-StaticArrays = "0.11, 0.12, 1.0"
 julia = "1"
 
 [extras]

--- a/src/LinearElasticity.jl
+++ b/src/LinearElasticity.jl
@@ -34,10 +34,10 @@ struct EngineeringStrain{T} <: Strain{T,1}
     data::Vec{6,T}
 end
 struct StiffnessMatrix{T} <: Stiffness{T,2}
-    data::SymmetricSecondOrderTensor{3,T,21}
+    data::SymmetricSecondOrderTensor{6,T,21}
 end
 struct ComplianceMatrix{T} <: Compliance{T,2}
-    data::SymmetricSecondOrderTensor{3,T,21}
+    data::SymmetricSecondOrderTensor{6,T,21}
 end
 
 TensorStress(x::EngineeringStress) = convert(TensorStress{eltype(x)}, x)

--- a/src/LinearElasticity.jl
+++ b/src/LinearElasticity.jl
@@ -66,24 +66,21 @@ Base.getindex(A::Union{Stress,Strain,Stiffness,Compliance}, i...) = getindex(A.d
 Base.IndexStyle(::Type{<:Union{Stress,Strain,Stiffness,Compliance}}) = IndexLinear()
 
 for T in (:TensorStress, :TensorStrain)
-    # See https://juliaarrays.github.io/StaticArrays.jl/stable/pages/api/#StaticArrays.SHermitianCompact
     @eval begin
-        $T(m::AbstractMatrix) = $T(SHermitianCompact{3}(m))
-        $T(v::AbstractVector) = $T(SHermitianCompact(SVector{6}(v)))
-        $T(t::NTuple{9}) = $T(SHermitianCompact{3}(t))
+        $T(m::AbstractMatrix) = $T(SymmetricSecondOrderTensor{3}(m))
+        $T(data...) = $T(SymmetricSecondOrderTensor{3}(data...))
     end
 end
 for T in (:EngineeringStress, :EngineeringStrain)
-    # See https://juliaarrays.github.io/StaticArrays.jl/stable/pages/api/#StaticArrays.SHermitianCompact
     @eval begin
-        $T(v::AbstractVector) = $T(SVector{6}(v))
+        $T(v::AbstractVector) = $T(Vec{6}(v))
+        $T(data...) = $T(Vec{6}(data...))
     end
 end
 for T in (:StiffnessMatrix, :ComplianceMatrix)
     @eval begin
-        $T(m::AbstractMatrix) = $T(SHermitianCompact{6}(m))
-        $T(v::AbstractVector) = $T(SHermitianCompact(SVector{21}(v)))
-        $T(t::NTuple{36}) = $T(SHermitianCompact{6}(t))
+        $T(m::AbstractMatrix) = $T(SymmetricSecondOrderTensor{6}(m))
+        $T(data...) = $T(SymmetricSecondOrderTensor{6}(data...))
     end
 end
 

--- a/src/LinearElasticity.jl
+++ b/src/LinearElasticity.jl
@@ -1,7 +1,7 @@
 module LinearElasticity
 
 using StaticArrays: SHermitianCompact, SMatrix, SVector
-using Tensorial: SymmetricFourthOrderTensor
+using Tensorial: SymmetricSecondOrderTensor, SymmetricFourthOrderTensor, Vec
 
 export TensorStress,
     TensorStrain,
@@ -17,28 +17,28 @@ abstract type Strain{T,N} <: AbstractArray{T,N} end
 abstract type Stiffness{T,N} <: AbstractArray{T,N} end
 abstract type Compliance{T,N} <: AbstractArray{T,N} end
 struct TensorStress{T} <: Stress{T,2}
-    data::SHermitianCompact{3,T}
+    data::SymmetricSecondOrderTensor{3,T,6}
 end
 struct TensorStrain{T} <: Strain{T,2}
-    data::SHermitianCompact{3,T}
+    data::SymmetricSecondOrderTensor{3,T,6}
 end
 struct StiffnessTensor{T} <: Stiffness{T,4}
-    data::SymmetricFourthOrderTensor{3,T}
+    data::SymmetricFourthOrderTensor{3,T,21}
 end
 struct ComplianceTensor{T} <: Compliance{T,4}
-    data::SymmetricFourthOrderTensor{3,T}
+    data::SymmetricFourthOrderTensor{3,T,21}
 end
 struct EngineeringStress{T} <: Stress{T,1}
-    data::SVector{6,T}
+    data::Vec{6,T}
 end
 struct EngineeringStrain{T} <: Strain{T,1}
-    data::SVector{6,T}
+    data::Vec{6,T}
 end
 struct StiffnessMatrix{T} <: Stiffness{T,2}
-    data::SHermitianCompact{6,T}
+    data::SymmetricSecondOrderTensor{3,T,21}
 end
 struct ComplianceMatrix{T} <: Compliance{T,2}
-    data::SHermitianCompact{6,T}
+    data::SymmetricSecondOrderTensor{3,T,21}
 end
 
 TensorStress(x::EngineeringStress) = convert(TensorStress{eltype(x)}, x)

--- a/src/LinearElasticity.jl
+++ b/src/LinearElasticity.jl
@@ -1,6 +1,5 @@
 module LinearElasticity
 
-using StaticArrays: SHermitianCompact, SMatrix, SVector
 using Tensorial: SymmetricSecondOrderTensor, SymmetricFourthOrderTensor, Vec
 
 export TensorStress,

--- a/src/LinearElasticity.jl
+++ b/src/LinearElasticity.jl
@@ -22,10 +22,10 @@ struct TensorStrain{T} <: Strain{T,2}
     data::SymmetricSecondOrderTensor{3,T,6}
 end
 struct StiffnessTensor{T} <: Stiffness{T,4}
-    data::SymmetricFourthOrderTensor{3,T,21}
+    data::SymmetricFourthOrderTensor{3,T}
 end
 struct ComplianceTensor{T} <: Compliance{T,4}
-    data::SymmetricFourthOrderTensor{3,T,21}
+    data::SymmetricFourthOrderTensor{3,T}
 end
 struct EngineeringStress{T} <: Stress{T,1}
     data::Vec{6,T}

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -10,39 +10,38 @@ Base.inv(c::StiffnessMatrix) = ComplianceMatrix(inv(c.data))
 Base.inv(s::ComplianceMatrix) = StiffnessMatrix(inv(s.data))
 
 Base.convert(::Type{TensorStress{T}}, s::EngineeringStress{T}) where {T} =
-    TensorStress([s[1], s[6], s[5], s[2], s[4], s[3]])
+    TensorStress(s[1], s[6], s[5], s[2], s[4], s[3])
 Base.convert(::Type{EngineeringStress{T}}, σ::TensorStress{T}) where {T} =
-    EngineeringStress([σ[1, 1], σ[2, 2], σ[3, 3], σ[2, 3], σ[1, 3], σ[1, 2]])
+    EngineeringStress(σ[1, 1], σ[2, 2], σ[3, 3], σ[2, 3], σ[1, 3], σ[1, 2])
 Base.convert(::Type{TensorStrain{T}}, ϵ::EngineeringStrain{T}) where {T} =
-    TensorStrain([ϵ[1], ϵ[6] / 2, ϵ[5] / 2, ϵ[2], ϵ[4] / 2, ϵ[3]])
+    TensorStrain(ϵ[1], ϵ[6] / 2, ϵ[5] / 2, ϵ[2], ϵ[4] / 2, ϵ[3])
 Base.convert(::Type{EngineeringStrain{T}}, ε::TensorStrain{T}) where {T} =
-    EngineeringStrain([ε[1, 1], ε[2, 2], ε[3, 3], 2ε[2, 3], 2ε[1, 3], 2ε[1, 2]])
-Base.convert(::Type{StiffnessMatrix{T}}, c::StiffnessTensor{T}) where {T} =
-    StiffnessMatrix([
-        c[1, 1, 1, 1],
-        c[1, 1, 2, 2],
-        c[1, 1, 3, 3],
-        c[1, 1, 2, 3],
-        c[1, 1, 1, 3],
-        c[1, 1, 1, 2],
-        c[2, 2, 2, 2],
-        c[2, 2, 3, 3],
-        c[2, 2, 2, 3],
-        c[2, 2, 1, 3],
-        c[2, 2, 1, 2],
-        c[3, 3, 3, 3],
-        c[3, 3, 2, 3],
-        c[3, 3, 1, 3],
-        c[3, 3, 1, 2],
-        c[2, 3, 2, 3],
-        c[2, 3, 1, 3],
-        c[2, 3, 1, 2],
-        c[1, 3, 1, 3],
-        c[1, 3, 1, 2],
-        c[1, 2, 1, 2],
-    ])
+    EngineeringStrain(ε[1, 1], ε[2, 2], ε[3, 3], 2ε[2, 3], 2ε[1, 3], 2ε[1, 2])
+Base.convert(::Type{StiffnessMatrix{T}}, c::StiffnessTensor{T}) where {T} = StiffnessMatrix(
+    c[1, 1, 1, 1],
+    c[1, 1, 2, 2],
+    c[1, 1, 3, 3],
+    c[1, 1, 2, 3],
+    c[1, 1, 1, 3],
+    c[1, 1, 1, 2],
+    c[2, 2, 2, 2],
+    c[2, 2, 3, 3],
+    c[2, 2, 2, 3],
+    c[2, 2, 1, 3],
+    c[2, 2, 1, 2],
+    c[3, 3, 3, 3],
+    c[3, 3, 2, 3],
+    c[3, 3, 1, 3],
+    c[3, 3, 1, 2],
+    c[2, 3, 2, 3],
+    c[2, 3, 1, 3],
+    c[2, 3, 1, 2],
+    c[1, 3, 1, 3],
+    c[1, 3, 1, 2],
+    c[1, 2, 1, 2],
+)
 Base.convert(::Type{ComplianceMatrix{T}}, s::ComplianceTensor{T}) where {T} =
-    ComplianceMatrix([
+    ComplianceMatrix(
         s[1, 1, 1, 1],
         s[1, 1, 2, 2],
         s[1, 1, 3, 3],
@@ -64,7 +63,7 @@ Base.convert(::Type{ComplianceMatrix{T}}, s::ComplianceTensor{T}) where {T} =
         4s[1, 3, 1, 3],
         4s[1, 3, 1, 2],
         4s[1, 2, 1, 2],
-    ])
+    )
 Base.convert(::Type{StiffnessTensor{T}}, c::StiffnessMatrix{T}) where {T} =
     StiffnessTensor(fromvoigt(SymmetricFourthOrderTensor{3,T}, c.data))
 function Base.convert(::Type{ComplianceTensor{T}}, s::ComplianceMatrix{T}) where {T}

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,4 +1,4 @@
-using Tensorial: fromvoigt, ⊡
+using Tensorial: fromvoigt, ⊡, ⋅
 
 import Tensorial: contraction, double_contraction
 
@@ -82,8 +82,8 @@ function Base.convert(::Type{ComplianceTensor{T}}, s::ComplianceMatrix{T}) where
     )
 end
 
-Base.:*(c::StiffnessMatrix, ϵ::EngineeringStrain) = EngineeringStress(c.data * ϵ.data)
-Base.:*(s::ComplianceMatrix, σ::EngineeringStress) = EngineeringStrain(s.data * σ.data)
+Base.:*(c::StiffnessMatrix, ϵ::EngineeringStrain) = EngineeringStress(c.data ⋅ ϵ.data)
+Base.:*(s::ComplianceMatrix, σ::EngineeringStress) = EngineeringStrain(s.data ⋅ σ.data)
 
 contraction(c::StiffnessTensor, ε::TensorStrain, ::Val{2}) = TensorStress(c.data ⊡ ε.data)
 contraction(s::ComplianceTensor, σ::TensorStress, ::Val{2}) = TensorStrain(s.data ⊡ σ.data)


### PR DESCRIPTION
- Fix constructors of `TensorStress`, `EngineeringStress` & `StiffnessMatrix`, etc.
- Fix `*` for `StiffnessMatrix` & `EngineeringStrain`, etc.