### PR TITLE
Deprecate `ElasticModulus` types, just use functions

### DIFF
--- a/src/Isotropic.jl
+++ b/src/Isotropic.jl
@@ -3,10 +3,10 @@ module Isotropic
 export bulk, young, lame1st, shear, poisson, longitudinal
 
 bulk(; kwargs...) = bulk(NamedTuple(kwargs))
-bulk((E, λ)::NamedTuple{(:E, :λ)}) = (E + 3 * λ + _auxiliaryR(E, λ)) / 6
+bulk((E, λ)::NamedTuple{(:E, :λ)}) = (E + 3 * λ + _R(E, λ)) / 6
 bulk((E, G)::NamedTuple{(:E, :G)}) = E * G / (3 * (3 * G - E))
 bulk((E, ν)::NamedTuple{(:E, :ν)}) = E / (3 * (1 - 2 * ν))
-bulk((E, M)::NamedTuple{(:E, :M)}) = (3 * M - E + _auxiliaryS(E, M)) / 6
+bulk((E, M)::NamedTuple{(:E, :M)}) = (3 * M - E + _S(E, M)) / 6
 bulk((λ, G)::NamedTuple{(:λ, :G)}) = λ + 2 * G / 3
 bulk((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 + ν) / 3 / ν
 bulk((λ, M)::NamedTuple{(:λ, :M)}) = (M + 2 * λ) / 3
@@ -35,7 +35,7 @@ lamé1st((K, ν)::NamedTuple{(:K, :ν)}) = 3K * ν / (1 + ν)
 lamé1st((K, M)::NamedTuple{(:K, :M)}) = (3K - M) / 2
 lamé1st((E, G)::NamedTuple{(:E, :G)}) = G * (E - 2G) / (3G - E)
 lamé1st((E, ν)::NamedTuple{(:E, :ν)}) = E * ν / (1 + ν) / (1 - 2ν)
-lamé1st((E, M)::NamedTuple{(:E, :M)}) = (M - E + _auxiliaryS(E, M)) / 4
+lamé1st((E, M)::NamedTuple{(:E, :M)}) = (M - E + _S(E, M)) / 4
 lamé1st((G, ν)::NamedTuple{(:G, :ν)}) = 2G * ν / (1 - 2ν)
 lamé1st((G, M)::NamedTuple{(:G, :M)}) = M - 2G
 lamé1st((ν, M)::NamedTuple{(:ν, :M)}) = M * ν / (1 - ν)
@@ -47,9 +47,9 @@ shear((K, E)::NamedTuple{(:K, :E)}) = 3K * E / (9K - E)
 shear((K, λ)::NamedTuple{(:K, :λ)}) = 3(K - λ) / 2
 shear((K, ν)::NamedTuple{(:K, :ν)}) = 3K * (1 - 2ν) / 2 / (1 + ν)
 shear((K, M)::NamedTuple{(:K, :M)}) = 3(M - K) / 4
-shear((E, λ)::NamedTuple{(:E, :λ)}) = (E - 3λ + _auxiliaryR(E, λ)) / 4
+shear((E, λ)::NamedTuple{(:E, :λ)}) = (E - 3λ + _R(E, λ)) / 4
 shear((E, ν)::NamedTuple{(:E, :ν)}) = E / 2 / (1 + ν)
-shear((E, M)::NamedTuple{(:E, :M)}) = (3M + E - _auxiliaryS(E, M)) / 8
+shear((E, M)::NamedTuple{(:E, :M)}) = (3M + E - _S(E, M)) / 8
 shear((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 - 2ν) / 2 / ν
 shear((λ, M)::NamedTuple{(:λ, :M)}) = (M - λ) / 2
 shear((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 - 2ν) / 2 / (1 - ν)
@@ -62,9 +62,9 @@ poisson((K, E)::NamedTuple{(:K, :E)}) = (3K - E) / 6 / K
 poisson((K, λ)::NamedTuple{(:K, :λ)}) = λ / (3K - λ)
 poisson((K, G)::NamedTuple{(:K, :G)}) = (3K - 2G) / 2 / (3K + G)
 poisson((K, M)::NamedTuple{(:K, :M)}) = (3K - M) / (3K + M)
-poisson((E, λ)::NamedTuple{(:E, :λ)}) = 2λ / (E + λ + _auxiliaryR(E, λ))
+poisson((E, λ)::NamedTuple{(:E, :λ)}) = 2λ / (E + λ + _R(E, λ))
 poisson((E, G)::NamedTuple{(:E, :G)}) = E / 2 / G - 1
-poisson((E, M)::NamedTuple{(:E, :M)}) = (E - M + _auxiliaryS(E, M)) / 4 / M
+poisson((E, M)::NamedTuple{(:E, :M)}) = (E - M + _S(E, M)) / 4 / M
 poisson((λ, G)::NamedTuple{(:λ, :G)}) = λ / 2 / (λ + G)
 poisson((λ, M)::NamedTuple{(:λ, :M)}) = λ / (M + λ)
 poisson((G, M)::NamedTuple{(:G, :M)}) = (M - 2G) / 2 / (M - G)
@@ -75,7 +75,7 @@ longitudinal((K, E)::NamedTuple{(:K, :E)}) = 3K * (3K + E) / (9K - E)
 longitudinal((K, λ)::NamedTuple{(:K, :λ)}) = 3K - 2λ
 longitudinal((K, G)::NamedTuple{(:K, :G)}) = K + 4G / 3
 longitudinal((K, ν)::NamedTuple{(:K, :ν)}) = 3K * (1 - ν) / (1 + ν)
-longitudinal((E, λ)::NamedTuple{(:E, :λ)}) = (E - λ + _auxiliaryR(E, λ)) / 2
+longitudinal((E, λ)::NamedTuple{(:E, :λ)}) = (E - λ + _R(E, λ)) / 2
 longitudinal((E, G)::NamedTuple{(:E, :G)}) = G * (4G - E) / (3G - E)
 longitudinal((E, ν)::NamedTuple{(:E, :ν)}) = E * (1 - ν) / (1 + ν) / (1 - 2ν)
 longitudinal((λ, G)::NamedTuple{(:λ, :G)}) = λ + 2G
@@ -85,8 +85,8 @@ longitudinal(x::NamedTuple) = haskey(x, :M) ? x[:M] : longitudinal(_reverse(x))
 const constrained = longitudinal
 
 # These are helper functions and should not be exported!
-_auxiliaryR(E, λ) = sqrt(E^2 + 9 * λ^2 + 2 * E * λ)
-_auxiliaryS(E, M) = sqrt(E^2 + 9 * M^2 - 10 * E * M)
+_R(E, λ) = sqrt(E^2 + 9 * λ^2 + 2 * E * λ)
+_S(E, M) = sqrt(E^2 + 9 * M^2 - 10 * E * M)
 
 _reverse(x::NamedTuple) = (; zip(reverse(propertynames(x)), reverse(values(x)))...)
 

--- a/src/Isotropic.jl
+++ b/src/Isotropic.jl
@@ -3,29 +3,29 @@ module Isotropic
 export bulk, young, lame1st, shear, poisson, longitudinal
 
 bulk(; kwargs...) = bulk(NamedTuple(kwargs))
-bulk((E, λ)::NamedTuple{(:E, :λ)}) = (E + 3 * λ + _R(E, λ)) / 6
-bulk((E, G)::NamedTuple{(:E, :G)}) = E * G / (3 * (3 * G - E))
-bulk((E, ν)::NamedTuple{(:E, :ν)}) = E / (3 * (1 - 2 * ν))
-bulk((E, M)::NamedTuple{(:E, :M)}) = (3 * M - E + _S(E, M)) / 6
-bulk((λ, G)::NamedTuple{(:λ, :G)}) = λ + 2 * G / 3
-bulk((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 + ν) / 3 / ν
-bulk((λ, M)::NamedTuple{(:λ, :M)}) = (M + 2 * λ) / 3
-bulk((G, ν)::NamedTuple{(:G, :ν)}) = 2 * G * (1 + ν) / (3 * (1 - 2 * ν))
-bulk((G, M)::NamedTuple{(:G, :M)}) = M - 4 * G / 3
-bulk((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 + ν) / (3 * (1 - ν))
+bulk((E, λ)::NamedTuple{(:E, :λ)}) = (E + 3λ + _R(E, λ)) / 6
+bulk((E, G)::NamedTuple{(:E, :G)}) = E * G / 3(3G - E)
+bulk((E, ν)::NamedTuple{(:E, :ν)}) = E / 3(1 - 2ν)
+bulk((E, M)::NamedTuple{(:E, :M)}) = (3M - E + _S(E, M)) / 6
+bulk((λ, G)::NamedTuple{(:λ, :G)}) = λ + 2G / 3
+bulk((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 + ν) / 3ν
+bulk((λ, M)::NamedTuple{(:λ, :M)}) = (M + 2λ) / 3
+bulk((G, ν)::NamedTuple{(:G, :ν)}) = 2G * (1 + ν) / 3(1 - 2ν)
+bulk((G, M)::NamedTuple{(:G, :M)}) = M - 4G / 3
+bulk((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 + ν) / 3(1 - ν)
 bulk(x::NamedTuple) = haskey(x, :K) ? x[:K] : bulk(_reverse(x))
 
 young(; kwargs...) = young(NamedTuple(kwargs))
-young((K, λ)::NamedTuple{(:K, :λ)}) = 9 * K * (K - λ) / (3 * K - λ)
-young((K, G)::NamedTuple{(:K, :G)}) = 9 * K * G / (3 * K + G)
-young((K, ν)::NamedTuple{(:K, :ν)}) = 3 * K * (1 - 2 * ν)
-young((K, M)::NamedTuple{(:K, :M)}) = 9 * K * (M - K) / (3 * K + M)
-young((λ, G)::NamedTuple{(:λ, :G)}) = G * (3 * λ + 2 * G) / (λ + G)
-young((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 + ν) * (1 - 2 * ν) / ν
-young((λ, M)::NamedTuple{(:λ, :M)}) = (M - λ) * (M + 2 * λ) / (M + λ)
-young((G, ν)::NamedTuple{(:G, :ν)}) = 2 * G * (1 + ν)
-young((G, M)::NamedTuple{(:G, :M)}) = G * (3 * M - 4 * G) / (M - G)
-young((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 + ν) * (1 - 2 * ν) / (1 - ν)
+young((K, λ)::NamedTuple{(:K, :λ)}) = 9K * (K - λ) / (3K - λ)
+young((K, G)::NamedTuple{(:K, :G)}) = 9K * G / (3K + G)
+young((K, ν)::NamedTuple{(:K, :ν)}) = 3K * (1 - 2ν)
+young((K, M)::NamedTuple{(:K, :M)}) = 9K * (M - K) / (3K + M)
+young((λ, G)::NamedTuple{(:λ, :G)}) = G * (3λ + 2G) / (λ + G)
+young((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 + ν) * (1 - 2ν) / ν
+young((λ, M)::NamedTuple{(:λ, :M)}) = (M - λ) * (M + 2λ) / (M + λ)
+young((G, ν)::NamedTuple{(:G, :ν)}) = 2G * (1 + ν)
+young((G, M)::NamedTuple{(:G, :M)}) = G * (3M - 4G) / (M - G)
+young((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 + ν) * (1 - 2ν) / (1 - ν)
 young(x::NamedTuple) = haskey(x, :E) ? x[:E] : young(_reverse(x))
 
 lamé1st(; kwargs...) = lamé1st(NamedTuple(kwargs))
@@ -45,29 +45,29 @@ const lame1st = lamé1st
 shear(; kwargs...) = shear(NamedTuple(kwargs))
 shear((K, E)::NamedTuple{(:K, :E)}) = 3K * E / (9K - E)
 shear((K, λ)::NamedTuple{(:K, :λ)}) = 3(K - λ) / 2
-shear((K, ν)::NamedTuple{(:K, :ν)}) = 3K * (1 - 2ν) / 2 / (1 + ν)
+shear((K, ν)::NamedTuple{(:K, :ν)}) = 3K * (1 - 2ν) / 2(1 + ν)
 shear((K, M)::NamedTuple{(:K, :M)}) = 3(M - K) / 4
 shear((E, λ)::NamedTuple{(:E, :λ)}) = (E - 3λ + _R(E, λ)) / 4
-shear((E, ν)::NamedTuple{(:E, :ν)}) = E / 2 / (1 + ν)
+shear((E, ν)::NamedTuple{(:E, :ν)}) = E / 2(1 + ν)
 shear((E, M)::NamedTuple{(:E, :M)}) = (3M + E - _S(E, M)) / 8
-shear((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 - 2ν) / 2 / ν
+shear((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 - 2ν) / 2ν
 shear((λ, M)::NamedTuple{(:λ, :M)}) = (M - λ) / 2
-shear((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 - 2ν) / 2 / (1 - ν)
+shear((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 - 2ν) / 2(1 - ν)
 shear(x::NamedTuple) = haskey(x, :G) ? x[:G] : shear(_reverse(x))
 const lamé2nd = shear
 const lame2nd = shear
 
 poisson(; kwargs...) = poisson(NamedTuple(kwargs))
-poisson((K, E)::NamedTuple{(:K, :E)}) = (3K - E) / 6 / K
+poisson((K, E)::NamedTuple{(:K, :E)}) = (3K - E) / 6K
 poisson((K, λ)::NamedTuple{(:K, :λ)}) = λ / (3K - λ)
-poisson((K, G)::NamedTuple{(:K, :G)}) = (3K - 2G) / 2 / (3K + G)
+poisson((K, G)::NamedTuple{(:K, :G)}) = (3K - 2G) / 2(3K + G)
 poisson((K, M)::NamedTuple{(:K, :M)}) = (3K - M) / (3K + M)
 poisson((E, λ)::NamedTuple{(:E, :λ)}) = 2λ / (E + λ + _R(E, λ))
-poisson((E, G)::NamedTuple{(:E, :G)}) = E / 2 / G - 1
-poisson((E, M)::NamedTuple{(:E, :M)}) = (E - M + _S(E, M)) / 4 / M
-poisson((λ, G)::NamedTuple{(:λ, :G)}) = λ / 2 / (λ + G)
+poisson((E, G)::NamedTuple{(:E, :G)}) = E / 2G - 1
+poisson((E, M)::NamedTuple{(:E, :M)}) = (E - M + _S(E, M)) / 4M
+poisson((λ, G)::NamedTuple{(:λ, :G)}) = λ / 2(λ + G)
 poisson((λ, M)::NamedTuple{(:λ, :M)}) = λ / (M + λ)
-poisson((G, M)::NamedTuple{(:G, :M)}) = (M - 2G) / 2 / (M - G)
+poisson((G, M)::NamedTuple{(:G, :M)}) = (M - 2G) / 2(M - G)
 poisson(x::NamedTuple) = haskey(x, :ν) ? x[:ν] : poisson(_reverse(x))
 
 longitudinal(; kwargs...) = longitudinal(NamedTuple(kwargs))
@@ -85,8 +85,8 @@ longitudinal(x::NamedTuple) = haskey(x, :M) ? x[:M] : longitudinal(_reverse(x))
 const constrained = longitudinal
 
 # These are helper functions and should not be exported!
-_R(E, λ) = sqrt(E^2 + 9 * λ^2 + 2 * E * λ)
-_S(E, M) = sqrt(E^2 + 9 * M^2 - 10 * E * M)
+_R(E, λ) = sqrt(E^2 + 9λ^2 + 2E * λ)
+_S(E, M) = sqrt(E^2 + 9M^2 - 10E * M)
 
 _reverse(x::NamedTuple) = (; zip(reverse(propertynames(x)), reverse(values(x)))...)
 

--- a/src/Isotropic.jl
+++ b/src/Isotropic.jl
@@ -1,115 +1,51 @@
 module Isotropic
 
-export BulkModulus,
-    YoungModulus,
-    Lamé1stParameter,
-    Lame1stParameter,
-    ShearModulus,
-    Lamé2ndParameter,
-    Lame2ndParameter,
-    PoissonRatio,
-    LongitudinalModulus,
-    unpack
+export bulk, young, lamé1st
 
-abstract type ElasticModulus{T} end
-struct BulkModulus{T} <: ElasticModulus{T}
-    v::T
-end
-struct YoungModulus{T} <: ElasticModulus{T}
-    v::T
-end
-struct Lamé1stParameter{T} <: ElasticModulus{T}
-    v::T
-end
-const Lame1stParameter = Lamé1stParameter
-struct ShearModulus{T} <: ElasticModulus{T}
-    v::T
-end
-const Lamé2ndParameter = ShearModulus
-const Lame2ndParameter = Lamé2ndParameter
-struct PoissonRatio{T} <: ElasticModulus{T}
-    v::T
-end
-struct LongitudinalModulus{T} <: ElasticModulus{T}
-    v::T
-end
+bulk(; kwargs...) = bulk(NamedTuple(kwargs))
+bulk((E, λ)::NamedTuple{(:E, :λ)}) = (E + 3 * λ + _auxiliaryR(E, λ)) / 6
+bulk((E, G)::NamedTuple{(:E, :G)}) = E * G / (3 * (3 * G - E))
+bulk((E, ν)::NamedTuple{(:E, :ν)}) = E / (3 * (1 - 2 * ν))
+bulk((E, M)::NamedTuple{(:E, :M)}) = (3 * M - E + _auxiliaryS(E, M))
+bulk((λ, G)::NamedTuple{(:λ, :G)}) = λ + 2 * G / 3
+bulk((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 + ν) / 3 / ν
+bulk((λ, M)::NamedTuple{(:λ, :M)}) = (M + 2 * λ) / 3
+bulk((G, ν)::NamedTuple{(:G, :ν)}) = 2 * G * (1 + ν) / (3 * (1 - 2 * ν))
+bulk((G, M)::NamedTuple{(:G, :M)}) = M - 4 * G / 3
+bulk((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 + ν) / (3 * (1 - ν))
+bulk(x::NamedTuple) = haskey(x, :K) ? x[:K] : bulk(_reverse(x))
 
-BulkModulus(E::YoungModulus, λ::Lamé1stParameter) =
-    BulkModulus((E.v + 3 * λ.v + _auxiliaryR(E, λ)) / 6)
-BulkModulus(E::YoungModulus, G::ShearModulus) =
-    BulkModulus(E.v * G.v / (3 * (3 * G.v - E.v)))
-BulkModulus(E::YoungModulus, ν::PoissonRatio) = BulkModulus(E.v / (3 * (1 - 2 * ν.v)))
-BulkModulus(E::YoungModulus, M::LongitudinalModulus) =
-    BulkModulus((3 * M.v - E.v + _auxiliaryS(E, M)))
-BulkModulus(λ::Lamé1stParameter, G::ShearModulus) = BulkModulus(λ.v + 2 * G.v / 3)
-BulkModulus(λ::Lamé1stParameter, ν::PoissonRatio) = BulkModulus(λ.v * (1 + ν.v) / 3 / ν.v)
-BulkModulus(λ::Lamé1stParameter, M::LongitudinalModulus) = BulkModulus((M.v + 2 * λ.v) / 3)
-BulkModulus(G::ShearModulus, ν::PoissonRatio) =
-    BulkModulus(2 * G.v * (1 + ν.v) / (3 * (1 - 2 * ν.v)))
-BulkModulus(G::ShearModulus, M::LongitudinalModulus) = BulkModulus(M.v - 4 * G.v / 3)
-BulkModulus(ν::PoissonRatio, M::LongitudinalModulus) =
-    BulkModulus(M.v * (1 + ν.v) / (3 * (1 - ν.v)))
+young(; kwargs...) = young(NamedTuple(kwargs))
+young((K, λ)::NamedTuple{(:K, :λ)}) = 9 * K * (K - λ) / (3 * K - λ)
+young((K, G)::NamedTuple{(:K, :G)}) = 9 * K * G / (3 * K + G)
+young((K, ν)::NamedTuple{(:K, :ν)}) = 3 * K * (1 - 2 * ν)
+young((K, M)::NamedTuple{(:K, :M)}) = 9 * K * (M - K) / (3 * K + M)
+young((λ, G)::NamedTuple{(:λ, :G)}) = G * (3 * λ + 2 * G) / (λ + G)
+young((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 + ν) * (1 - 2 * ν) / ν
+young((λ, M)::NamedTuple{(:λ, :M)}) = (M - λ) * (M + 2 * λ) / (M + λ)
+young((G, ν)::NamedTuple{(:G, :ν)}) = 2 * G * (1 + ν)
+young((G, M)::NamedTuple{(:G, :M)}) = G * (3 * M - 4 * G) / (M - G)
+young((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 + ν) * (1 - 2 * ν) / (1 - ν)
+young(x::NamedTuple) = haskey(x, :E) ? x[:E] : young(_reverse(x))
 
-YoungModulus(K::BulkModulus, λ::Lamé1stParameter) =
-    YoungModulus(9 * K.v * (K.v - λ.v) / (3 * K.v - λ.v))
-YoungModulus(K::BulkModulus, G::ShearModulus) =
-    YoungModulus(9 * K.v * G.v / (3 * K.v + G.v))
-YoungModulus(K::BulkModulus, ν::PoissonRatio) = YoungModulus(3 * K.v * (1 - 2 * ν.v))
-YoungModulus(K::BulkModulus, M::LongitudinalModulus) =
-    YoungModulus(9 * K.v * (M.v - K.v) / (3 * K.v + M.v))
-YoungModulus(λ::Lamé1stParameter, G::ShearModulus) =
-    YoungModulus(G.v * (3 * λ.v + 2 * G.v) / (λ.v + G.v))
-YoungModulus(λ::Lamé1stParameter, ν::PoissonRatio) =
-    YoungModulus(λ.v * (1 + ν.v) * (1 - 2 * ν.v) / ν.v)
-YoungModulus(λ::Lamé1stParameter, M::LongitudinalModulus) =
-    YoungModulus((M.v - λ.v) * (M.v + 2 * λ.v) / (M.v + λ.v))
-YoungModulus(G::ShearModulus, ν::PoissonRatio) = YoungModulus(2 * G.v * (1 + ν.v))
-YoungModulus(G::ShearModulus, M::LongitudinalModulus) =
-    YoungModulus(G.v * (3 * M.v - 4 * G.v) / (M.v - G.v))
-YoungModulus(ν::PoissonRatio, M::LongitudinalModulus) =
-    YoungModulus(M.v * (1 + ν.v) * (1 - 2 * ν.v) / (1 - ν.v))
-
-Lamé1stParameter(K::BulkModulus, E::YoungModulus) =
-    Lamé1stParameter((9K.v^2 - 3K.v * E.v) / (9K.v - E.v))
-Lamé1stParameter(K::BulkModulus, G::ShearModulus) = Lamé1stParameter(K.v - 2G.v / 3)
-Lamé1stParameter(K::BulkModulus, ν::PoissonRatio) = Lamé1stParameter(3K.v * ν.v / (1 + ν.v))
-Lamé1stParameter(K::BulkModulus, M::LongitudinalModulus) =
-    Lamé1stParameter((3K.v - M.v) / 2)
-Lamé1stParameter(E::YoungModulus, G::ShearModulus) =
-    Lamé1stParameter(G.v * (E.v - 2G.v) / (3G.v - E.v))
-Lamé1stParameter(E::YoungModulus, ν::PoissonRatio) =
-    Lamé1stParameter(E.v * ν.v / (1 + ν.v) / (1 - 2ν.v))
-Lamé1stParameter(E::YoungModulus, M::LongitudinalModulus) =
-    Lamé1stParameter((M.v - E.v + _auxiliaryS(E, M)) / 4)
-Lamé1stParameter(G::ShearModulus, ν::PoissonRatio) =
-    Lamé1stParameter(2G.v * ν.v / (1 - 2ν.v))
-Lamé1stParameter(G::ShearModulus, M::ShearModulus) = Lamé1stParameter(M.v - 2G.v)
-Lamé1stParameter(ν::PoissonRatio, M::LongitudinalModulus) =
-    Lamé1stParameter(M.v * ν.v / (1 - ν.v))
+lamé1st(; kwargs...) = lamé1st(NamedTuple(kwargs))
+lamé1st((K, E)::NamedTuple{(:K, :E)}) = (9K^2 - 3K * E) / (9K - E)
+lamé1st((K, G)::NamedTuple{(:K, :G)}) = K - 2G / 3
+lamé1st((K, ν)::NamedTuple{(:K, :ν)}) = 3K * ν / (1 + ν)
+lamé1st((K, M)::NamedTuple{(:K, :M)}) = (3K - M) / 2
+lamé1st((E, G)::NamedTuple{(:E, :G)}) = G * (E - 2G) / (3G - E)
+lamé1st((E, ν)::NamedTuple{(:E, :ν)}) = E * ν / (1 + ν) / (1 - 2ν)
+lamé1st((E, M)::NamedTuple{(:E, :M)}) = (M - E + _auxiliaryS(E, M)) / 4
+lamé1st((G, ν)::NamedTuple{(:G, :ν)}) = 2G * ν / (1 - 2ν)
+lamé1st((G, M)::NamedTuple{(:G, :M)}) = M - 2G
+lamé1st((ν, M)::NamedTuple{(:ν, :M)}) = M * ν / (1 - ν)
+lamé1st(x::NamedTuple) = haskey(x, :λ) ? x[:λ] : lamé1st(_reverse(x))
+const lame1st = lamé1st
 
 # These are helper functions and should not be exported!
-_auxiliaryR(E::YoungModulus, λ::Lamé1stParameter) = sqrt(E.v^2 + 9 * λ.v^2 + 2 * E.v * λ.v)
-_auxiliaryS(E::YoungModulus, M::LongitudinalModulus) =
-    sqrt(E.v^2 + 9 * M.v^2 - 10 * E.v * M.v)
+_auxiliaryR(E, λ) = sqrt(E^2 + 9 * λ^2 + 2 * E * λ)
+_auxiliaryS(E, M) = sqrt(E^2 + 9 * M^2 - 10 * E * M)
 
-unpack(x::ElasticModulus) = getfield(x, :v)
-unpack(x::ElasticModulus...) = unpack.(x)
-unpack(x::AbstractArray{<:ElasticModulus}) = unpack.(x)
-
-for T in (
-    :BulkModulus,
-    :YoungModulus,
-    :Lame1stParameter,
-    :ShearModulus,
-    :PoissonRatio,
-    :LongitudinalModulus,
-)
-    @eval begin  # See https://github.com/JuliaLang/julia/blob/45c518d/base/fastmath.jl#L253-L259
-        # As long as creating from one parameter already defined, return the parameter itself.
-        $T(x::$T, ::ElasticModulus) = x
-        # If there is no method match, switch the parameters and try again.
-        $T(x::ElasticModulus, y::ElasticModulus) = $T(y, x)
-    end
-end
+_reverse(x::NamedTuple) = (; zip(reverse(propertynames(x)), reverse(values(x)))...)
 
 end

--- a/src/Isotropic.jl
+++ b/src/Isotropic.jl
@@ -69,6 +69,24 @@ YoungModulus(G::ShearModulus, M::LongitudinalModulus) =
 YoungModulus(ν::PoissonRatio, M::LongitudinalModulus) =
     YoungModulus(M.v * (1 + ν.v) * (1 - 2 * ν.v) / (1 - ν.v))
 
+Lamé1stParameter(K::BulkModulus, E::YoungModulus) =
+    Lamé1stParameter((9K.v^2 - 3K.v * E.v) / (9K.v - E.v))
+Lamé1stParameter(K::BulkModulus, G::ShearModulus) = Lamé1stParameter(K.v - 2G.v / 3)
+Lamé1stParameter(K::BulkModulus, ν::PoissonRatio) = Lamé1stParameter(3K.v * ν.v / (1 + ν.v))
+Lamé1stParameter(K::BulkModulus, M::LongitudinalModulus) =
+    Lamé1stParameter((3K.v - M.v) / 2)
+Lamé1stParameter(E::YoungModulus, G::ShearModulus) =
+    Lamé1stParameter(G.v * (E.v - 2G.v) / (3G.v - E.v))
+Lamé1stParameter(E::YoungModulus, ν::PoissonRatio) =
+    Lamé1stParameter(E.v * ν.v / (1 + ν.v) / (1 - 2ν.v))
+Lamé1stParameter(E::YoungModulus, M::LongitudinalModulus) =
+    Lamé1stParameter((M.v - E.v + _auxiliaryS(E, M)) / 4)
+Lamé1stParameter(G::ShearModulus, ν::PoissonRatio) =
+    Lamé1stParameter(2G.v * ν.v / (1 - 2ν.v))
+Lamé1stParameter(G::ShearModulus, M::ShearModulus) = Lamé1stParameter(M.v - 2G.v)
+Lamé1stParameter(ν::PoissonRatio, M::LongitudinalModulus) =
+    Lamé1stParameter(M.v * ν.v / (1 - ν.v))
+
 # These are helper functions and should not be exported!
 _auxiliaryR(E::YoungModulus, λ::Lamé1stParameter) = sqrt(E.v^2 + 9 * λ.v^2 + 2 * E.v * λ.v)
 _auxiliaryS(E::YoungModulus, M::LongitudinalModulus) =

--- a/src/Isotropic.jl
+++ b/src/Isotropic.jl
@@ -1,6 +1,6 @@
 module Isotropic
 
-export bulk, young, lame1st, shear, poisson
+export bulk, young, lame1st, shear, poisson, longitudinal
 
 bulk(; kwargs...) = bulk(NamedTuple(kwargs))
 bulk((E, λ)::NamedTuple{(:E, :λ)}) = (E + 3 * λ + _auxiliaryR(E, λ)) / 6
@@ -69,6 +69,20 @@ poisson((λ, G)::NamedTuple{(:λ, :G)}) = λ / 2 / (λ + G)
 poisson((λ, M)::NamedTuple{(:λ, :M)}) = λ / (M + λ)
 poisson((G, M)::NamedTuple{(:G, :M)}) = (M - 2G) / 2 / (M - G)
 poisson(x::NamedTuple) = haskey(x, :ν) ? x[:ν] : poisson(_reverse(x))
+
+longitudinal(; kwargs...) = longitudinal(NamedTuple(kwargs))
+longitudinal((K, E)::NamedTuple{(:K, :E)}) = 3K * (3K + E) / (9K - E)
+longitudinal((K, λ)::NamedTuple{(:K, :λ)}) = 3K - 2λ
+longitudinal((K, G)::NamedTuple{(:K, :G)}) = K + 4G / 3
+longitudinal((K, ν)::NamedTuple{(:K, :ν)}) = 3K * (1 - ν) / (1 + ν)
+longitudinal((E, λ)::NamedTuple{(:E, :λ)}) = (E - λ + _auxiliaryR(E, λ)) / 2
+longitudinal((E, G)::NamedTuple{(:E, :G)}) = G * (4G - E) / (3G - E)
+longitudinal((E, ν)::NamedTuple{(:E, :ν)}) = E * (1 - ν) / (1 + ν) / (1 - 2ν)
+longitudinal((λ, G)::NamedTuple{(:λ, :G)}) = λ + 2G
+longitudinal((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 - ν) / ν
+longitudinal((G, ν)::NamedTuple{(:G, :ν)}) = 2G * (1 - ν) / (1 - 2ν)
+longitudinal(x::NamedTuple) = haskey(x, :M) ? x[:M] : longitudinal(_reverse(x))
+const constrained = longitudinal
 
 # These are helper functions and should not be exported!
 _auxiliaryR(E, λ) = sqrt(E^2 + 9 * λ^2 + 2 * E * λ)

--- a/src/Isotropic.jl
+++ b/src/Isotropic.jl
@@ -2,6 +2,8 @@ module Isotropic
 
 export bulk, young, lame1st, shear, poisson, longitudinal
 
+const ALLOWED_KEYS = (:K, :E, :λ, :G, :ν, :M)
+
 bulk(; kwargs...) = bulk(NamedTuple(kwargs))
 bulk((E, λ)::NamedTuple{(:E, :λ)}) = (E + 3λ + _R(E, λ)) / 6
 bulk((E, G)::NamedTuple{(:E, :G)}) = E * G / 3(3G - E)
@@ -13,7 +15,10 @@ bulk((λ, M)::NamedTuple{(:λ, :M)}) = (M + 2λ) / 3
 bulk((G, ν)::NamedTuple{(:G, :ν)}) = 2G * (1 + ν) / 3(1 - 2ν)
 bulk((G, M)::NamedTuple{(:G, :M)}) = M - 4G / 3
 bulk((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 + ν) / 3(1 - ν)
-bulk(x::NamedTuple) = haskey(x, :K) ? x[:K] : bulk(_reverse(x))
+function bulk(x::NamedTuple)
+    _checkkeys(x)
+    return haskey(x, :K) ? x[:K] : bulk(_reverse(x))
+end
 
 young(; kwargs...) = young(NamedTuple(kwargs))
 young((K, λ)::NamedTuple{(:K, :λ)}) = 9K * (K - λ) / (3K - λ)
@@ -26,7 +31,10 @@ young((λ, M)::NamedTuple{(:λ, :M)}) = (M - λ) * (M + 2λ) / (M + λ)
 young((G, ν)::NamedTuple{(:G, :ν)}) = 2G * (1 + ν)
 young((G, M)::NamedTuple{(:G, :M)}) = G * (3M - 4G) / (M - G)
 young((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 + ν) * (1 - 2ν) / (1 - ν)
-young(x::NamedTuple) = haskey(x, :E) ? x[:E] : young(_reverse(x))
+function young(x::NamedTuple)
+    _checkkeys(x)
+    return haskey(x, :E) ? x[:E] : young(_reverse(x))
+end
 
 lamé1st(; kwargs...) = lamé1st(NamedTuple(kwargs))
 lamé1st((K, E)::NamedTuple{(:K, :E)}) = (9K^2 - 3K * E) / (9K - E)
@@ -39,7 +47,10 @@ lamé1st((E, M)::NamedTuple{(:E, :M)}) = (M - E + _S(E, M)) / 4
 lamé1st((G, ν)::NamedTuple{(:G, :ν)}) = 2G * ν / (1 - 2ν)
 lamé1st((G, M)::NamedTuple{(:G, :M)}) = M - 2G
 lamé1st((ν, M)::NamedTuple{(:ν, :M)}) = M * ν / (1 - ν)
-lamé1st(x::NamedTuple) = haskey(x, :λ) ? x[:λ] : lamé1st(_reverse(x))
+function lamé1st(x::NamedTuple)
+    _checkkeys(x)
+    return haskey(x, :λ) ? x[:λ] : lamé1st(_reverse(x))
+end
 const lame1st = lamé1st
 
 shear(; kwargs...) = shear(NamedTuple(kwargs))
@@ -53,7 +64,10 @@ shear((E, M)::NamedTuple{(:E, :M)}) = (3M + E - _S(E, M)) / 8
 shear((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 - 2ν) / 2ν
 shear((λ, M)::NamedTuple{(:λ, :M)}) = (M - λ) / 2
 shear((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 - 2ν) / 2(1 - ν)
-shear(x::NamedTuple) = haskey(x, :G) ? x[:G] : shear(_reverse(x))
+function shear(x::NamedTuple)
+    _checkkeys(x)
+    return haskey(x, :G) ? x[:G] : shear(_reverse(x))
+end
 const lamé2nd = shear
 const lame2nd = shear
 
@@ -68,7 +82,10 @@ poisson((E, M)::NamedTuple{(:E, :M)}) = (E - M + _S(E, M)) / 4M
 poisson((λ, G)::NamedTuple{(:λ, :G)}) = λ / 2(λ + G)
 poisson((λ, M)::NamedTuple{(:λ, :M)}) = λ / (M + λ)
 poisson((G, M)::NamedTuple{(:G, :M)}) = (M - 2G) / 2(M - G)
-poisson(x::NamedTuple) = haskey(x, :ν) ? x[:ν] : poisson(_reverse(x))
+function poisson(x::NamedTuple)
+    _checkkeys(x)
+    return haskey(x, :ν) ? x[:ν] : poisson(_reverse(x))
+end
 
 longitudinal(; kwargs...) = longitudinal(NamedTuple(kwargs))
 longitudinal((K, E)::NamedTuple{(:K, :E)}) = 3K * (3K + E) / (9K - E)
@@ -81,7 +98,10 @@ longitudinal((E, ν)::NamedTuple{(:E, :ν)}) = E * (1 - ν) / (1 + ν) / (1 - 2�
 longitudinal((λ, G)::NamedTuple{(:λ, :G)}) = λ + 2G
 longitudinal((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 - ν) / ν
 longitudinal((G, ν)::NamedTuple{(:G, :ν)}) = 2G * (1 - ν) / (1 - 2ν)
-longitudinal(x::NamedTuple) = haskey(x, :M) ? x[:M] : longitudinal(_reverse(x))
+function longitudinal(x::NamedTuple)
+    _checkkeys(x)
+    return haskey(x, :M) ? x[:M] : longitudinal(_reverse(x))
+end
 const constrained = longitudinal
 
 # These are helper functions and should not be exported!
@@ -89,5 +109,7 @@ _R(E, λ) = sqrt(E^2 + 9λ^2 + 2E * λ)
 _S(E, M) = sqrt(E^2 + 9M^2 - 10E * M)  # FIXME: ±S
 
 _reverse(x::NamedTuple) = (; zip(reverse(propertynames(x)), reverse(values(x)))...)
+
+_checkkeys(x) = @assert all(key ∈ ALLOWED_KEYS for key in propertynames(x))
 
 end

--- a/src/Isotropic.jl
+++ b/src/Isotropic.jl
@@ -1,12 +1,12 @@
 module Isotropic
 
-export bulk, young, lame1st, shear
+export bulk, young, lame1st, shear, poisson
 
 bulk(; kwargs...) = bulk(NamedTuple(kwargs))
 bulk((E, λ)::NamedTuple{(:E, :λ)}) = (E + 3 * λ + _auxiliaryR(E, λ)) / 6
 bulk((E, G)::NamedTuple{(:E, :G)}) = E * G / (3 * (3 * G - E))
 bulk((E, ν)::NamedTuple{(:E, :ν)}) = E / (3 * (1 - 2 * ν))
-bulk((E, M)::NamedTuple{(:E, :M)}) = (3 * M - E + _auxiliaryS(E, M))
+bulk((E, M)::NamedTuple{(:E, :M)}) = (3 * M - E + _auxiliaryS(E, M)) / 6
 bulk((λ, G)::NamedTuple{(:λ, :G)}) = λ + 2 * G / 3
 bulk((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 + ν) / 3 / ν
 bulk((λ, M)::NamedTuple{(:λ, :M)}) = (M + 2 * λ) / 3
@@ -56,6 +56,19 @@ shear((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 - 2ν) / 2 / (1 - ν)
 shear(x::NamedTuple) = haskey(x, :G) ? x[:G] : shear(_reverse(x))
 const lamé2nd = shear
 const lame2nd = shear
+
+poisson(; kwargs...) = poisson(NamedTuple(kwargs))
+poisson((K, E)::NamedTuple{(:K, :E)}) = (3K - E) / 6 / K
+poisson((K, λ)::NamedTuple{(:K, :λ)}) = λ / (3K - λ)
+poisson((K, G)::NamedTuple{(:K, :G)}) = (3K - 2G) / 2 / (3K + G)
+poisson((K, M)::NamedTuple{(:K, :M)}) = (3K - M) / (3K + M)
+poisson((E, λ)::NamedTuple{(:E, :λ)}) = 2λ / (E + λ + _auxiliaryR(E, λ))
+poisson((E, G)::NamedTuple{(:E, :G)}) = E / 2 / G - 1
+poisson((E, M)::NamedTuple{(:E, :M)}) = (E - M + _auxiliaryS(E, M)) / 4 / M
+poisson((λ, G)::NamedTuple{(:λ, :G)}) = λ / 2 / (λ + G)
+poisson((λ, M)::NamedTuple{(:λ, :M)}) = λ / (M + λ)
+poisson((G, M)::NamedTuple{(:G, :M)}) = (M - 2G) / 2 / (M - G)
+poisson(x::NamedTuple) = haskey(x, :ν) ? x[:ν] : poisson(_reverse(x))
 
 # These are helper functions and should not be exported!
 _auxiliaryR(E, λ) = sqrt(E^2 + 9 * λ^2 + 2 * E * λ)

--- a/src/Isotropic.jl
+++ b/src/Isotropic.jl
@@ -1,6 +1,6 @@
 module Isotropic
 
-export bulk, young, lamé1st
+export bulk, young, lame1st, shear
 
 bulk(; kwargs...) = bulk(NamedTuple(kwargs))
 bulk((E, λ)::NamedTuple{(:E, :λ)}) = (E + 3 * λ + _auxiliaryR(E, λ)) / 6
@@ -41,6 +41,21 @@ lamé1st((G, M)::NamedTuple{(:G, :M)}) = M - 2G
 lamé1st((ν, M)::NamedTuple{(:ν, :M)}) = M * ν / (1 - ν)
 lamé1st(x::NamedTuple) = haskey(x, :λ) ? x[:λ] : lamé1st(_reverse(x))
 const lame1st = lamé1st
+
+shear(; kwargs...) = shear(NamedTuple(kwargs))
+shear((K, E)::NamedTuple{(:K, :E)}) = 3K * E / (9K - E)
+shear((K, λ)::NamedTuple{(:K, :λ)}) = 3(K - λ) / 2
+shear((K, ν)::NamedTuple{(:K, :ν)}) = 3K * (1 - 2ν) / 2 / (1 + ν)
+shear((K, M)::NamedTuple{(:K, :M)}) = 3(M - K) / 4
+shear((E, λ)::NamedTuple{(:E, :λ)}) = (E - 3λ + _auxiliaryR(E, λ)) / 4
+shear((E, ν)::NamedTuple{(:E, :ν)}) = E / 2 / (1 + ν)
+shear((E, M)::NamedTuple{(:E, :M)}) = (3M + E - _auxiliaryS(E, M)) / 8
+shear((λ, ν)::NamedTuple{(:λ, :ν)}) = λ * (1 - 2ν) / 2 / ν
+shear((λ, M)::NamedTuple{(:λ, :M)}) = (M - λ) / 2
+shear((ν, M)::NamedTuple{(:ν, :M)}) = M * (1 - 2ν) / 2 / (1 - ν)
+shear(x::NamedTuple) = haskey(x, :G) ? x[:G] : shear(_reverse(x))
+const lamé2nd = shear
+const lame2nd = shear
 
 # These are helper functions and should not be exported!
 _auxiliaryR(E, λ) = sqrt(E^2 + 9 * λ^2 + 2 * E * λ)

--- a/src/Isotropic.jl
+++ b/src/Isotropic.jl
@@ -86,7 +86,7 @@ const constrained = longitudinal
 
 # These are helper functions and should not be exported!
 _R(E, λ) = sqrt(E^2 + 9λ^2 + 2E * λ)
-_S(E, M) = sqrt(E^2 + 9M^2 - 10E * M)
+_S(E, M) = sqrt(E^2 + 9M^2 - 10E * M)  # FIXME: ±S
 
 _reverse(x::NamedTuple) = (; zip(reverse(propertynames(x)), reverse(values(x)))...)
 


### PR DESCRIPTION
- Avoid complicated type arithmetic
- Avoid complex type dispatches