### PR TITLE
Deprecate methods `lsqfit`, use type `ElasticConstantFitter`

### DIFF
--- a/src/distort.jl
+++ b/src/distort.jl
@@ -1,5 +1,5 @@
-using CrystallographyBase: Lattice, CrystalSystem, Cubic
-using LinearAlgebra: I, svd, diagm, qr
+using CrystallographyBase: Lattice, CrystalSystem, Cubic, Hexagonal
+using LinearAlgebra: I, norm, dot
 
 export distort, lsqfit
 
@@ -16,7 +16,7 @@ function lsqfit(ϵ::EngineeringStrain, σ::EngineeringStress, ::Cubic)
         ϵ₂+ϵ₃ ϵ₁+ϵ₃ ϵ₂+ϵ₁
     ]
     c₁₁, c₁₂ = inv(Aᵀ * transpose(Aᵀ)) * Aᵀ * σ[1:3]  # If 𝐴 is well-conditioned, using the normal equations is around as accurate as other methods and is also the fastest. https://math.stackexchange.com/a/3252377/115512
-    c₄₄ = σ[4] / ϵ[4]
+    c₄₄ = dot(ϵ[4:6], σ[4:6]) / sum(abs2, ϵ[4:6])  # B = ϵ[4:6], c₄₄ = inv(Bᵀ * B) * Bᵀ * σ[4:6]
     𝟘 = zero(c₁₁)
     return StiffnessMatrix(
         [

--- a/src/distort.jl
+++ b/src/distort.jl
@@ -33,7 +33,14 @@ function (::ElasticConstantFitter{Cubic})(ϵ::EngineeringStrain, σ::Engineering
         ],
     )
 end
+(x::ElasticConstantFitter)(
+    ϵ::EngineeringStrain,
+    σ::EngineeringStress,
+    σ₀::EngineeringStress,
+) = x(ϵ, σ - σ₀)
 function (x::ElasticConstantFitter)(ϵ::TensorStrain, σ::TensorStress)
     c = x(EngineeringStrain(ϵ), EngineeringStress(σ))
     return StiffnessTensor(c)
 end
+(x::ElasticConstantFitter)(ϵ::TensorStrain, σ::TensorStress, σ₀::TensorStress) =
+    x(ϵ, σ - σ₀)

--- a/src/distort.jl
+++ b/src/distort.jl
@@ -33,14 +33,10 @@ function (::ElasticConstantFitter{Cubic})(ϵ::EngineeringStrain, σ::Engineering
         ],
     )
 end
-(x::ElasticConstantFitter)(
-    ϵ::EngineeringStrain,
-    σ::EngineeringStress,
-    σ₀::EngineeringStress,
-) = x(ϵ, σ - σ₀)
 function (x::ElasticConstantFitter)(ϵ::TensorStrain, σ::TensorStress)
     c = x(EngineeringStrain(ϵ), EngineeringStress(σ))
     return StiffnessTensor(c)
 end
-(x::ElasticConstantFitter)(ϵ::TensorStrain, σ::TensorStress, σ₀::TensorStress) =
-    x(ϵ, σ - σ₀)
+for (X, Y) in ((:EngineeringStrain, :EngineeringStress), (:TensorStrain, :TensorStress))
+    @eval (x::ElasticConstantFitter)(ϵ::$X, σ::$Y, σ₀::$Y) = x(ϵ, σ - σ₀)
+end


### PR DESCRIPTION
and Fix `lsqfit` for `Cubic` using least squares method, not just calculations